### PR TITLE
feat(cache): add cache_force param, cache delete CLI, and xetrack API…

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -53,6 +53,30 @@
         "ml-ops",
         "reproducibility"
       ]
+    },
+    {
+      "name": "xetrack",
+      "source": "./skills/xetrack",
+      "description": "API reference and usage guide for xetrack — lightweight experiment tracking with SQLite/DuckDB. Covers Tracker, Reader, caching, CLI, and common patterns.",
+      "version": "0.5.2",
+      "author": {
+        "name": "XDSS"
+      },
+      "homepage": "https://github.com/xdssio/xetrack",
+      "repository": "https://github.com/xdssio/xetrack",
+      "license": "MIT",
+      "category": "ml-tools",
+      "keywords": [
+        "xetrack",
+        "tracker",
+        "reader",
+        "api-reference",
+        "experiment-tracking",
+        "caching",
+        "sqlite",
+        "duckdb",
+        "cli"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -372,6 +372,48 @@ for key, cached_data in Reader.scan_cache('cache_dir'):
 - **API Calls**: Cache external API responses (with appropriate TTL considerations)
 - **Scientific Computing**: Cache results of long-running simulations
 
+### Force Cache Refresh
+
+Use `cache_force=True` to skip the cache lookup and re-execute the function. The new result overwrites the existing cache entry:
+
+```python
+# Normal call — uses cache if available
+result = tracker.track(expensive_computation, args=[2, 10])
+
+# Force refresh — re-executes the function and overwrites the cache
+result = tracker.track(expensive_computation, args=[2, 10], cache_force=True)
+
+# Next normal call will use the refreshed cache entry
+result = tracker.track(expensive_computation, args=[2, 10])  # Cache hit (from force-refreshed entry)
+```
+
+**When to use `cache_force`:**
+- Model or data changed but function signature is the same
+- Cached result might be stale or corrupted
+- You want to re-run a specific computation without clearing the entire cache
+
+### Delete Cache Entries
+
+Remove all cache entries associated with a specific experiment run:
+
+```python
+from xetrack import Reader
+
+# Delete all cache entries produced by a specific track_id
+deleted = Reader.delete_cache_by_track_id('cache_dir', 'cool-name-1234')
+print(f"Deleted {deleted} cache entries")
+```
+
+**CLI:**
+
+```bash
+# List all cache entries with their track_id lineage
+xt cache ls cache_dir
+
+# Delete cache entries by track_id
+xt cache delete cache_dir cool-name-1234
+```
+
 ### Important Notes
 
 - **Cache keys** are generated from tuples of (function name, args, kwargs, **tracker params**)
@@ -650,6 +692,10 @@ $ xt tail database.db --n=1
 $ xt set database.db accuracy 0.8 --where-key params --where-value 1b5b2294fc521d12 --track-id ebony-loon-6720
 
 $ xt delete database.db ebony-loon-6720 # delete experiments with a given track_id
+
+# Cache management
+$ xt cache ls cache_dir                         # list cache entries with track_id lineage
+$ xt cache delete cache_dir cool-name-1234      # delete cache entries for a specific run
 
 # run any other SQL in a oneliner
 $ xt sql database.db "SELECT * FROM db.events;"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "xetrack"
-version = "0.5.1"
+version = "0.5.2"
 description = "A simple tool for benchamrking and tracking machine learning models and experiments."
 readme = "README.md"
 packages = [{ include = "xetrack" }]

--- a/skills/benchmark/.claude-plugin/plugin.json
+++ b/skills/benchmark/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "benchmark",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Comprehensive ML/AI benchmarking skill that guides users through rigorous experiment design, execution, and analysis using xetrack",
   "author": {
     "name": "XDSS"

--- a/skills/git-versioning/.claude-plugin/plugin.json
+++ b/skills/git-versioning/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-versioning",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "ML experiment versioning using Git + DVC + xetrack + DuckDB. Guides sequential, parallel, and worktree-based experiment workflows with merge/rebase semantics.",
   "author": {
     "name": "XDSS"

--- a/skills/xetrack/.claude-plugin/plugin.json
+++ b/skills/xetrack/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "xetrack",
+  "version": "0.5.2",
+  "description": "API reference and usage guide for xetrack — lightweight experiment tracking with SQLite/DuckDB",
+  "author": {
+    "name": "XDSS"
+  },
+  "homepage": "https://github.com/xdssio/xetrack",
+  "repository": "https://github.com/xdssio/xetrack",
+  "license": "MIT",
+  "keywords": [
+    "xetrack",
+    "tracker",
+    "reader",
+    "experiment-tracking",
+    "sqlite",
+    "duckdb",
+    "caching",
+    "diskcache",
+    "cli",
+    "api-reference"
+  ]
+}

--- a/skills/xetrack/SKILL.md
+++ b/skills/xetrack/SKILL.md
@@ -1,0 +1,470 @@
+---
+name: xetrack
+description: API reference and usage patterns for xetrack — lightweight experiment tracking with SQLite/DuckDB. Use when writing code that uses xetrack, when unsure about Tracker or Reader API, when using the xt CLI, when working with caching/diskcache, or when tracking ML experiments. Triggers on "xetrack", "Tracker", "Reader", "tracker.track", "tracker.log", "xt cli", "xetrack cache", "experiment tracking", "track function", "track metrics".
+---
+
+# xetrack API Reference
+
+xetrack is a lightweight experiment tracking tool. It stores metrics, parameters, and assets in SQLite or DuckDB. This skill is the canonical API reference — use it to write correct xetrack code.
+
+**DO NOT hallucinate APIs.** If a method isn't listed here, check the source before using it.
+
+## Install
+
+```bash
+pip install xetrack                      # Core (SQLite)
+pip install xetrack[duckdb]              # DuckDB engine
+pip install xetrack[cache]               # diskcache for function caching
+pip install xetrack[assets]              # sqlitedict for asset storage
+pip install xetrack[duckdb,cache,assets] # All extras
+```
+
+## Imports
+
+```python
+from xetrack import Tracker, Reader, copy
+```
+
+---
+
+## Tracker
+
+The main interface for tracking experiments.
+
+### Constructor
+
+```python
+Tracker(
+    db: str = "track.db",               # Database path, or ":memory:" for in-memory
+    params: Dict[str, Any] | None = None,# Default params attached to every event
+    reset: bool = False,                 # Drop and recreate events table
+    log_system_params: bool = False,     # Track CPU, RAM, disk usage
+    log_network_params: bool = False,    # Track bytes sent/received
+    raise_on_error: bool = True,         # Raise exceptions from tracked functions
+    measurement_interval: float = 1,     # System stats interval (seconds)
+    track_id: Optional[str] = None,      # Custom track ID (auto-generated if None)
+    logs_path: Optional[str] = None,     # Directory for log files
+    logs_file_format: Optional[str] = None, # Log file name format (e.g., "{time:YYYY-MM-DD}.log")
+    logs_stdout: bool = False,           # Print logs to stdout
+    jsonl: Optional[str] = None,         # Path to JSONL structured log file
+    cache: Optional[str] = None,         # Path to diskcache directory (enables function caching)
+    compress: bool = False,              # Compress database
+    warnings: bool = True,               # Show warnings
+    git_root: Optional[str] = None,      # Git root for commit hash tracking
+    engine: Literal["duckdb", "sqlite"] = "sqlite",  # Database engine
+    table: str = "default",              # Table name for multi-experiment support
+)
+```
+
+### Properties
+
+```python
+tracker.db          # str — database path
+tracker.conn        # database connection object
+tracker.table_name  # str — resolved table name
+tracker.columns     # list — column names in the events table
+tracker.dtypes      # dict — column name -> type mapping
+tracker.assets      # AssetsManager | None — asset storage (requires sqlitedict)
+tracker.track_id    # str — current track ID (e.g., "cool-name-1234")
+tracker.params      # dict — default params attached to every event
+tracker.latest      # dict — last logged event data
+```
+
+### Core Methods
+
+#### `tracker.log(data: dict) -> dict`
+
+Log arbitrary key-value data as an event. Adds `track_id` and `timestamp` automatically. Creates columns dynamically.
+
+```python
+tracker.log({"accuracy": 0.95, "loss": 0.05, "epoch": 10})
+tracker.log({"model": "bert", "dataset": "squad"})
+```
+
+**Returns:** The validated data dict (with track_id and timestamp added).
+
+#### `tracker.track(func, params=None, args=None, kwargs=None, cache_force=False)`
+
+Execute a function, log its execution metadata, and return the result. Automatically tracks `function_name`, `function_time`, `args`, `kwargs`, `error`, and the function's return value.
+
+```python
+def train(lr: float, epochs: int) -> dict:
+    return {"accuracy": 0.95, "loss": 0.05}
+
+# Basic tracking
+result = tracker.track(train, args=[0.01, 10])
+
+# With extra params (logged alongside function data)
+result = tracker.track(train, args=[0.01, 10], params={"model": "bert"})
+
+# With kwargs
+result = tracker.track(train, kwargs={"lr": 0.01, "epochs": 10})
+
+# Force cache refresh (skip cache read, rewrite entry)
+result = tracker.track(train, args=[0.01, 10], cache_force=True)
+```
+
+**Return value handling:**
+- If the function returns a `dict`, its keys are merged into the logged event as columns.
+- If the function returns a primitive (int, float, str, etc.), it's stored in `function_result`.
+- If the function returns a non-primitive, it's converted to string and stored in `function_result`.
+
+**Dataclass argument unpacking:**
+When arguments are `dataclass` or Pydantic `BaseModel` instances, their fields are automatically extracted as columns with `{param_name}_{field_name}` naming:
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class Config:
+    lr: float
+    batch_size: int
+
+def train(config: Config) -> dict:
+    return {"accuracy": 0.95}
+
+# Logs: config_lr=0.01, config_batch_size=32, accuracy=0.95
+tracker.track(train, args=[Config(lr=0.01, batch_size=32)])
+```
+
+#### `tracker.wrap(params=None)`
+
+Decorator factory for tracking functions.
+
+```python
+@tracker.wrap(params={"experiment": "baseline"})
+def predict(x):
+    return x * 2
+
+result = predict(5)  # Tracked automatically
+```
+
+#### `tracker.log_batch(data: List[dict]) -> dict`
+
+Log multiple events at once (batch insert).
+
+```python
+tracker.log_batch([
+    {"step": 1, "loss": 0.5},
+    {"step": 2, "loss": 0.3},
+    {"step": 3, "loss": 0.1},
+])
+```
+
+### Parameter Management
+
+```python
+tracker.set_param("model", "bert")         # Set a param for all future events
+tracker.set_params({"model": "bert", "version": "v2"})  # Set multiple
+tracker.set_value("accuracy", 0.95)        # Update value for this track_id
+tracker.set_where("label", "good", "accuracy", 0.95)  # Conditional update
+```
+
+### Query Methods
+
+```python
+tracker.to_df(all=False)       # DataFrame for this track_id (all=True for everything)
+tracker.head(n=5)              # First n rows for this track_id
+tracker.tail(n=5)              # Last n rows for this track_id
+tracker.count_all()            # Total record count in table
+tracker.count_run()            # Record count for this track_id
+len(tracker)                   # Same as count_run()
+tracker["accuracy"]            # Column values for this track_id (pd.Series)
+tracker[1]                     # First row as dict
+```
+
+### Export
+
+```python
+tracker.to_csv("output.csv", all=False)
+tracker.to_parquet("output.parquet", all=False)
+```
+
+### Assets
+
+Requires `pip install xetrack[assets]`. Stores complex Python objects with hash-based deduplication.
+
+```python
+# Objects are auto-stored as assets when logged via tracker.log()
+import sklearn.linear_model
+model = sklearn.linear_model.LinearRegression()
+tracker.log({"model_obj": model})  # Stored as asset, hash reference in DB
+
+# Retrieve
+tracker.get("model_obj_hash")
+```
+
+### Static/Utility
+
+```python
+Tracker.generate_track_id()           # -> "cool-name-1234"
+Tracker.IN_MEMORY                     # ":memory:" constant
+Tracker.SKIP_INSERT                   # Skip DB insert (logging only)
+```
+
+---
+
+## Caching (diskcache)
+
+Requires `pip install xetrack[cache]` or `pip install diskcache`.
+
+### How It Works
+
+When `cache` path is provided to `Tracker`, `tracker.track()` automatically caches function results:
+
+1. **Cache key** = `(module.func_name, args, kwargs, params)` — all must be hashable
+2. **Cache hit** = skip function execution, log cached result with lineage reference
+3. **Cache miss** = execute function, store result, log with empty cache field
+
+### Cache Lineage in DB
+
+The `cache` column in the DB tracks lineage:
+- `""` (empty string) = this row was computed fresh
+- `"cool-name-1234"` (a track_id) = this row was served from cache, originally computed by that track_id
+
+### cache_force
+
+Skip cache read and re-execute the function, overwriting the existing cache entry:
+
+```python
+# Normal (uses cache if available)
+result = tracker.track(func, args=[1, 2])
+
+# Force refresh (re-executes, overwrites cache)
+result = tracker.track(func, args=[1, 2], cache_force=True)
+```
+
+### What Gets Cached
+
+- Only successful executions (exceptions are NOT cached)
+- Only calls with fully hashable arguments (primitives, frozen dataclasses, objects with `__hash__`)
+- Unhashable args (lists, dicts, non-frozen dataclasses) silently skip caching
+
+### Frozen Dataclasses for Caching
+
+```python
+@dataclass(frozen=True)  # frozen=True makes it hashable -> cacheable
+class Config:
+    model: str
+    lr: float
+
+# Different Config values = different cache entries
+tracker.track(train, args=[Config("bert", 0.01)])    # Cached separately
+tracker.track(train, args=[Config("gpt", 0.01)])     # Cached separately
+tracker.track(train, args=[Config("bert", 0.01)])    # Cache hit!
+```
+
+---
+
+## Reader
+
+Read-only interface for accessing tracked data.
+
+### Constructor
+
+```python
+Reader(
+    db: str,                                          # Database path
+    engine: Literal["duckdb", "sqlite"] = "sqlite",   # Database engine
+    table: str = "default",                            # Table name
+)
+```
+
+### Properties
+
+```python
+reader.db          # str
+reader.conn        # database connection
+reader.columns     # list
+reader.dtypes      # dict
+reader.assets      # AssetsManager | None
+```
+
+### Query Methods
+
+```python
+reader.to_df(track_id=None, head=None, tail=None)  # -> pd.DataFrame
+reader.latest()                                      # -> pd.DataFrame (last track_id's data)
+len(reader)                                          # Total record count
+```
+
+### Data Modification
+
+```python
+reader.delete_run("cool-name-1234")                           # Delete all events for track_id
+reader.set_value("key", "value", track_id="cool-name-1234")   # Update value
+reader.set_where("key", "value", "where_key", "where_val", track_id=None)
+reader.remove_asset("hash", column=None, remove_keys=True)
+```
+
+### Class Methods — Database
+
+```python
+Reader.read_db(db, engine="sqlite", table="default", track_id=None, head=None, tail=None)
+```
+
+### Class Methods — Logs
+
+```python
+Reader.read_logs(path, limit=None)  # -> pd.DataFrame from log files
+Reader.read_jsonl(path)             # -> pd.DataFrame from JSONL file
+```
+
+### Class Methods — Cache
+
+```python
+# Read a specific cache entry by key
+Reader.read_cache(cache_path, key)  # -> dict {"result": ..., "cache": track_id} | None
+
+# Iterate all cache entries
+for key, cached_data in Reader.scan_cache(cache_path):
+    print(cached_data["result"], cached_data["cache"])
+
+# Delete all cache entries for a track_id
+deleted_count = Reader.delete_cache_by_track_id(cache_path, "cool-name-1234")
+```
+
+---
+
+## CLI (`xt`)
+
+### Database Queries
+
+```bash
+xt head db.db --n=10                              # First 10 rows
+xt tail db.db --n=10                              # Last 10 rows
+xt columns db.db                                  # List columns
+xt ls db.db                                       # List column names
+xt ls db.db track_id --unique                     # Unique track IDs
+xt sql db.db "SELECT * FROM \"default\" LIMIT 5"  # Raw SQL (quote 'default')
+```
+
+### Data Operations
+
+```bash
+xt set db.db key value --track-id=cool-name-1234
+xt delete db.db cool-name-1234
+xt copy source.db target.db --assets/--no-assets --table=default --table=other
+```
+
+### Cache Management
+
+```bash
+xt cache ls ./cache_dir                           # List cache entries with lineage
+xt cache delete ./cache_dir cool-name-1234        # Delete cache by track_id
+```
+
+### Asset Management
+
+```bash
+xt assets ls db.db                                # List all assets
+xt assets export db.db <hash> output.pkl          # Export asset to file
+xt assets delete db.db <hash>                     # Delete asset
+```
+
+### Statistics
+
+```bash
+xt stats describe db.db --columns=accuracy,loss   # Describe columns
+xt stats top db.db accuracy                       # Row with max accuracy
+xt stats bottom db.db loss                        # Row with min loss
+```
+
+### Plotting (requires `pip install xetrack[bashplotlib]`)
+
+```bash
+xt plot hist db.db accuracy --bins=20
+xt plot scatter db.db epoch loss
+```
+
+### Common Options
+
+All DB commands support:
+- `--engine sqlite|duckdb` (default: sqlite)
+- `--table <name>` (default: "default")
+- `--json` (head/tail only — output as JSON)
+
+---
+
+## copy()
+
+Copy data between databases (DuckDB only).
+
+```python
+from xetrack import copy
+
+# Copy default table with assets
+copy("source.db", "target.db")
+
+# Copy specific tables
+copy("source.db", "target.db", tables=["predictions", "metrics"])
+
+# Skip assets
+copy("source.db", "target.db", assets=False)
+```
+
+---
+
+## Engine Selection Guide
+
+| Feature | SQLite | DuckDB |
+|---|---|---|
+| Default | Yes | No (`pip install xetrack[duckdb]`) |
+| Concurrent writes | multiprocessing.Pool | ThreadPoolExecutor |
+| Table name in SQL | `"default"` (quoted) | `db.default` |
+| Best for | Local dev, single process | Analytics, parallel I/O |
+| copy() support | No | Yes |
+
+---
+
+## Common Patterns
+
+### Multi-Table Tracking
+
+```python
+pred_tracker = Tracker(db="exp.db", table="predictions", cache="cache")
+metrics_tracker = Tracker(db="exp.db", table="metrics")
+
+# Track predictions per-item
+for item in dataset:
+    pred_tracker.track(predict, args=[item, params])
+
+# Log aggregate metrics
+metrics_tracker.log({"accuracy": 0.95, "model": "bert"})
+```
+
+### JSONL Logging (for data synthesis pipelines)
+
+```python
+tracker = Tracker(db=Tracker.SKIP_INSERT, jsonl="output.jsonl", logs_stdout=True)
+tracker.log({"prompt": "...", "response": "...", "label": 1})
+
+# Read back
+df = Reader.read_jsonl("output.jsonl")
+```
+
+### Git Commit Tracking
+
+```python
+tracker = Tracker(db="exp.db", git_root=".")
+# Automatically adds git_commit column to every event
+```
+
+### System Resource Monitoring
+
+```python
+tracker = Tracker(db="exp.db", log_system_params=True, log_network_params=True)
+result = tracker.track(expensive_func, args=[data])
+# Logs: cpu_percent, ram_percent, p_memory_percent, disk_percent, bytes_sent, bytes_recv
+```
+
+---
+
+## Gotchas
+
+1. **Table name quoting:** SQLite table `default` is a reserved keyword. In raw SQL use `"default"` (quoted). The engine handles this automatically.
+2. **Unhashable args skip caching silently.** Lists, dicts, non-frozen dataclasses won't be cached. Use frozen dataclasses.
+3. **Multiple Trackers on same DB:** Each Tracker instance has its own `_columns` set. Creating a second Tracker on the same DB may trigger "duplicate column" errors if both try to log. Use a single Tracker or separate track_ids on the same instance.
+4. **Dynamic schema:** Columns are added on first use. If you rename a param, xetrack creates a NEW column — the old one stays with NULLs for new rows.
+5. **Assets require sqlitedict:** `tracker.assets` is `None` unless `pip install xetrack[assets]`.
+6. **DuckDB table names:** DuckDB uses `db.tablename` syntax. The engine handles this, but raw SQL queries need to use the right format.

--- a/xetrack/cli.py
+++ b/xetrack/cli.py
@@ -128,6 +128,35 @@ def sql(db: str = typer.Argument(help='path to database'),
     typer.echo(df.to_markdown())
 
 
+cache_app = typer.Typer(short_help="Cache management commands")
+app.add_typer(cache_app, name="cache")
+
+
+@cache_app.command(name="delete")
+def cache_delete(
+    cache_path: str = typer.Argument(help="Path to the cache directory"),
+    track_id: str = typer.Argument(help="Track ID whose cache entries should be deleted"),
+):
+    """Delete all cache entries associated with a specific track_id."""
+    deleted = Reader.delete_cache_by_track_id(cache_path, track_id)
+    typer.echo(f"Deleted {deleted} cache entries for track_id '{track_id}'")
+
+
+@cache_app.command(name="ls")
+def cache_ls(
+    cache_path: str = typer.Argument(help="Path to the cache directory"),
+):
+    """List all cached entries with their track_id lineage."""
+    entries = list(Reader.scan_cache(cache_path))
+    if not entries:
+        typer.echo("Cache is empty")
+        return
+    typer.echo(f"Cache entries in {cache_path}:\n")
+    for key, cached_data in entries:
+        track_id = cached_data.get("cache", "N/A") if isinstance(cached_data, dict) else "N/A"
+        typer.echo(f"  track_id: {track_id}  key: {key}")
+
+
 assets_app = typer.Typer(short_help="A helper for assets managments")
 app.add_typer(assets_app, name="assets")
 

--- a/xetrack/reader.py
+++ b/xetrack/reader.py
@@ -304,3 +304,41 @@ class Reader:
         cache_obj = Cache(cache)
         for key in cache_obj.iterkeys():
             yield key, cache_obj[key]
+
+    @classmethod
+    def delete_cache_by_track_id(cls, cache: str, track_id: str) -> int:
+        """
+        Delete all cache entries associated with a specific track_id.
+
+        Scans the cache and removes entries where the "cache" field (the track_id
+        that computed the result) matches the given track_id.
+
+        Args:
+            cache: Path to cache directory
+            track_id: The track_id whose cache entries should be deleted
+
+        Returns:
+            Number of cache entries deleted
+
+        Example:
+            >>> deleted = Reader.delete_cache_by_track_id("cache_dir", "cool-name-1234")
+            >>> print(f"Deleted {deleted} cache entries")
+        """
+        try:
+            from diskcache import Cache
+        except ImportError as e:
+            raise ImportError(
+                "diskcache is not installed. Please install it using `pip install xetrack[cache]` or `pip install diskcache`"
+            ) from e
+
+        cache_obj = Cache(cache)
+        keys_to_delete = []
+        for key in cache_obj.iterkeys():
+            cached_data = cache_obj[key]
+            if isinstance(cached_data, dict) and cached_data.get("cache") == track_id:
+                keys_to_delete.append(key)
+
+        for key in keys_to_delete:
+            del cache_obj[key]
+
+        return len(keys_to_delete)

--- a/xetrack/tracker.py
+++ b/xetrack/tracker.py
@@ -664,6 +664,7 @@ class Tracker:
         params: Optional[Dict[str, Any]] = None,
         args: Optional[List[Any]] = None,
         kwargs: Optional[Dict[str, Any]] = None,
+        cache_force: bool = False,
     ):
         """
         Executes a function and logs the execution data.
@@ -675,6 +676,7 @@ class Tracker:
             params (dict, optional): Additional parameters to log along with the execution data. Defaults to None.
             args (list, optional): Positional arguments to pass to the function. Defaults to None.
             kwargs (dict, optional): Keyword arguments to pass to the function. Defaults to None.
+            cache_force (bool): If True, skip cache lookup and re-execute the function, overwriting the cached result. Defaults to False.
 
         Returns:
             Any: The return value of the executed function.
@@ -691,9 +693,9 @@ class Tracker:
         cache_key = None
         if self.cache is not None:
             cache_key = self._generate_cache_key(func, args, kwargs, params)
-            if cache_key is not None and cache_key in self.cache:
+            if cache_key is not None and not cache_force and cache_key in self.cache:
                 cached_data = self.cache[cache_key]
-                # Log cache hit
+                # Log cache hit with the same result data as a normal execution
                 data = {
                     "function_name": func.__name__,
                     "args": str(list(args)),
@@ -702,6 +704,7 @@ class Tracker:
                     "error": "",
                     "function_time": 0.0,
                 }
+                data = self.validate_result(data, cached_data["result"])
                 data.update(params)
                 self.log(data)
                 return cached_data["result"]


### PR DESCRIPTION
… skill

- Add cache_force param to Tracker.track() to skip cache read and overwrite
- Fix cache hit logging to include actual result values (not just lineage)
- Add Reader.delete_cache_by_track_id() for targeted cache cleanup
- Add xt cache delete/ls CLI commands
- Add xetrack API reference skill for correct usage guidance
- Bump version to 0.5.2