### PR TITLE
refactor: replace stdlib json with orjson for speed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         echo "Using pip directly for Python 3.12 to avoid Poetry build issues"
         pip install --only-binary :all: numpy pandas scipy scikit-learn
-        pip install pytest duckdb sqlitedict bashplotlib psutil xxhash typer loguru tabulate cloudpickle coolname requests
+        pip install pytest duckdb sqlitedict bashplotlib psutil xxhash typer loguru tabulate cloudpickle coolname requests orjson diskcache polars
         pip install -e .
     
     - name: Install project (Poetry)

--- a/poetry.lock
+++ b/poetry.lock
@@ -384,6 +384,90 @@ files = [
 ]
 
 [[package]]
+name = "orjson"
+version = "3.11.9"
+description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "orjson-3.11.9-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:135869ef917b8704ea0a94e01620e0c05021c15c52036e4663baffe75e72f8ce"},
+    {file = "orjson-3.11.9-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:115ab5f5f4a0f203cc2a5f0fb09aee503a3f771aa08392949ab5ca230c4fbdbd"},
+    {file = "orjson-3.11.9-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4da3c38a2083ca4aaf9c2a36776cce3e9328e6647b10d118948f3cfb4913ffe4"},
+    {file = "orjson-3.11.9-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:53b50b0e14084b8f7e29c5ce84c5af0f1160169b30d8a6914231d97d2fe297d4"},
+    {file = "orjson-3.11.9-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:231742b4a11dad8d5380a435962c57e91b7c37b79be858f4ef1c0df1a259897e"},
+    {file = "orjson-3.11.9-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:34fd2317602587321faab75ab76c623a0117e80841a6413654f04e47f339a8fb"},
+    {file = "orjson-3.11.9-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:71f3db16e69b667b132e0f305a833d5497da302d801508cbb051ed9a9819da47"},
+    {file = "orjson-3.11.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0b34789fa0da61cf7bef0546b09c738fb195331e017e477096d129e9105ab03d"},
+    {file = "orjson-3.11.9-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:87e4d4ab280b0c87424d47695bec2182caf8cfc17879ea78dab76680194abc13"},
+    {file = "orjson-3.11.9-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:ace6c58523302d3b97b6ac5c38a5298a54b473762b6be82726b4265c41029f92"},
+    {file = "orjson-3.11.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:97d0d932803c1b164fde11cb542a9efcb1e0f63b184537cca65887147906ff48"},
+    {file = "orjson-3.11.9-cp310-cp310-win32.whl", hash = "sha256:b3afcf569c15577a9fe64627292daa3e6b3a70f4fb77a5df246a87ec21681b94"},
+    {file = "orjson-3.11.9-cp310-cp310-win_amd64.whl", hash = "sha256:8697ab6a080a5c46edaad50e2bc5bd8c7ca5c66442d24104fa44ec74910a8244"},
+    {file = "orjson-3.11.9-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:f01c4818b3fc9b0da8e096722a84318071eaa118df35f6ed2344da0e73a5444f"},
+    {file = "orjson-3.11.9-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:3ebca4179031ee716ed076ffadc29428e900512f6fccee8614c9983157fcf19c"},
+    {file = "orjson-3.11.9-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48ee05097750de0ff69ed5b7bbcf0732182fd57a24043dcc2a1da780a5ead3a5"},
+    {file = "orjson-3.11.9-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6082706765a95a6680d812e1daf1c0cfe8adec7831b3ff3b625693f3b461b1c"},
+    {file = "orjson-3.11.9-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:277fefe9d76ee17eb14debf399e3533d4d63b5f677a4d3719eb763536af1f4bd"},
+    {file = "orjson-3.11.9-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:03db380e3780fa0015ed776a90f20e8e20bb11dde13b216ce19e5718e3dfba62"},
+    {file = "orjson-3.11.9-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33d7d766701847dc6729846362dc27895d2f2d2251264f9d10e7cb9878194877"},
+    {file = "orjson-3.11.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:147302878da387104b66bb4a8b0227d1d487e976ce41a8501916161072ed87b1"},
+    {file = "orjson-3.11.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3513550321f8c8c811a7c3297b8a630e82dc08e4c10216d07703c997776236cd"},
+    {file = "orjson-3.11.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:c5d001196b89fa9cf0a4ab79766cd835b991a166e4b621ba95089edc50c429ff"},
+    {file = "orjson-3.11.9-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:16969c9d369c98eb084889c6e4d2d39b77c7eb38ceccf8da2a9fff62ae908980"},
+    {file = "orjson-3.11.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:63e0efbc991250c0b3143488fa57d95affcabbfc63c99c48d625dd37779aafe2"},
+    {file = "orjson-3.11.9-cp311-cp311-win32.whl", hash = "sha256:14ed654580c1ed2bc217352ec82f91b047aef82951aa71c7f64e0dcb03c0e180"},
+    {file = "orjson-3.11.9-cp311-cp311-win_amd64.whl", hash = "sha256:57ea77fb70a448ce87d18fca050193202a3da5e54598f6501ca5476fb66cfe02"},
+    {file = "orjson-3.11.9-cp311-cp311-win_arm64.whl", hash = "sha256:19b72ed11572a2ee51a67a903afbe5af504f84ed6f529c0fe44b0ab3fb5cc697"},
+    {file = "orjson-3.11.9-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9ef6fe90aadef185c7b128859f40beb24720b4ecea95379fc9000931179c3a49"},
+    {file = "orjson-3.11.9-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e5c9b8f28e726e97d97696c826bc7bea5d71cecd63576dba92924a32c1961291"},
+    {file = "orjson-3.11.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a473dbb4162108b27901492546f83c76fdcea3d0eadff00ae7a07e18dcce09"},
+    {file = "orjson-3.11.9-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:011382e2a60fda9d46f1cdee31068cfc52ffe952b587d683ec0463002802a0f4"},
+    {file = "orjson-3.11.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c2d3dc759490128c5c1711a53eeaa8ee1d437fd0038ffd2b6008abf46db3f882"},
+    {file = "orjson-3.11.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d8ea516b3726d190e1b4297e6f4e7a8650347ae053868a18163b4dd3641d1fff"},
+    {file = "orjson-3.11.9-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:380cdce7ba24989af81d0a7013d0aaec5d0e2a21734c0e2681b1bc4f141957fe"},
+    {file = "orjson-3.11.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4fa4f0af7fa18951f7ab3fc2148e223af211bf03f59e1c6034ec3f97f21d61"},
+    {file = "orjson-3.11.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a8f5f8bc7ce7d59f08d9f99fa510c06496164a24cb5f3d34537dbd9ca30132e2"},
+    {file = "orjson-3.11.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4d7fde5501b944f83b3e665e1b31343ff6e154b15560a16b7130ea1e594a4206"},
+    {file = "orjson-3.11.9-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cde1a448023ba7d5bb4c01c5afb48894380b5e4956e0627266526587ef4e535f"},
+    {file = "orjson-3.11.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e63adb0e1f1ed5d9e168f50a91ceb93ae6420731d222dc7da5c69409aa47aa"},
+    {file = "orjson-3.11.9-cp312-cp312-win32.whl", hash = "sha256:2d057a602cdd19a0ad680417527c45b6961a095081c0f46fe0e03e304aac6470"},
+    {file = "orjson-3.11.9-cp312-cp312-win_amd64.whl", hash = "sha256:59e403b1cc5a676da8eaf31f6254801b7341b3e29efa85f92b48d272637e77be"},
+    {file = "orjson-3.11.9-cp312-cp312-win_arm64.whl", hash = "sha256:9af678d6488357948f1f84c6cd1c1d397c014e1ae2f98ae082a44eb48f602624"},
+    {file = "orjson-3.11.9-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:4bab1b2d6141fe7b32ae71dac905666ece4f94936efbfb13d55bb7739a3a6021"},
+    {file = "orjson-3.11.9-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:844417969855fc7a41be124aafe83dc424592a7f77cd4501900c67307122b92c"},
+    {file = "orjson-3.11.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffe02797b5e9f3a9d8292ddcd289b474ad13e81ad83cd1891a240811f1d2cb81"},
+    {file = "orjson-3.11.9-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e4eed3b200023042814d2fc8a5d2e880f13b52e1ed2485e83da4f3962f7dc1a"},
+    {file = "orjson-3.11.9-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8aff7da9952a5ad1cef8e68017724d96c7b9a66e99e91d6252e1b133d67a7b10"},
+    {file = "orjson-3.11.9-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d4e98d6f3b8afed8bc8cd9718ec0cdf46661826beefb53fe8eafb37f2bf0362"},
+    {file = "orjson-3.11.9-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a81d52442a7c99b3662333235b3adf96a1715864658b35bb797212be7bddb97"},
+    {file = "orjson-3.11.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e39364e726a8fff737309aff059ff67d8a8c8d5b677be7bb49a8b3e84b7e218"},
+    {file = "orjson-3.11.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4fd66214623f1b17501df9f0543bef0b833979ab5b6ded1e1d123222866aa8c9"},
+    {file = "orjson-3.11.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:8ecc30f10465fa1e0ce13fd01d9e22c316e5053a719a8d915d4545a09a5ff677"},
+    {file = "orjson-3.11.9-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:97db4c94a7db398a5bd636273324f0b3fd58b350bbbac8bb380ceb825a9b40f4"},
+    {file = "orjson-3.11.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f78cf8fec5bd627f4082b8dfeac7871b43d7f3274904492a43dab39f18a19a0"},
+    {file = "orjson-3.11.9-cp313-cp313-win32.whl", hash = "sha256:d4087e5c0209a0a8efe4de3303c234b9c44d1174161dcd851e8eea07c7560b32"},
+    {file = "orjson-3.11.9-cp313-cp313-win_amd64.whl", hash = "sha256:051b102c93b4f634e89f3866b07b9a9a98915ada541f4ec30f177067b2694979"},
+    {file = "orjson-3.11.9-cp313-cp313-win_arm64.whl", hash = "sha256:cce9127885941bd28f080cecf1f1d288336b7e0d812c345b08be88b572796254"},
+    {file = "orjson-3.11.9-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:b6ef1979adc4bc243523f1a2ba91418030a8e29b0a99cbe7e0e2d6807d4dce6e"},
+    {file = "orjson-3.11.9-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:f36b7f32c7c0db4a719f1fc5824db4a9c6f8bd1a354debb91faf26ebf3a4c71e"},
+    {file = "orjson-3.11.9-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08f4d8ebb44925c794e535b2bebc507cebf32209df81de22ae285fb0d8d66de0"},
+    {file = "orjson-3.11.9-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6cc7923789694fd58f001cbcac7e47abc13af4d560ebbfcf3b41a8b1a0748124"},
+    {file = "orjson-3.11.9-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea5c46eb2d3af39e806b986f4b09d5c2706a1f5afde3cbf7544ce6616127173c"},
+    {file = "orjson-3.11.9-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5d89a2ed90731df3be64bab0aa44f78bff39fdc9d71c291f4a8023aa46425b7"},
+    {file = "orjson-3.11.9-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:25e4aed0312d292c09f61af25bba34e0b2c88546041472b09088c39a4d828af1"},
+    {file = "orjson-3.11.9-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aaea64f3f467d22e70eeed68bdccb3bc4f83f650446c4a03c59f2cba28a108db"},
+    {file = "orjson-3.11.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a028425d1b440c5d92a6be1e1a020739dfe67ea87d96c6dbe828c1b30041728b"},
+    {file = "orjson-3.11.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5b192c6cf397e4455b11523c5cf2b18ed084c1bbd61b6c0926344d2129481972"},
+    {file = "orjson-3.11.9-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea407d4ccf5891d667d045fecae97a7a1e5e87b3b97f97ae1803c2e741130be0"},
+    {file = "orjson-3.11.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f63aaf97afd9f6dec5b1a68e1b8da12bfccb4cb9a9a65c3e0b6c847849e7586"},
+    {file = "orjson-3.11.9-cp314-cp314-win32.whl", hash = "sha256:e30ab17845bb9fa54ccf67fa4f9f5282652d54faa6d17452f47d0f369d038673"},
+    {file = "orjson-3.11.9-cp314-cp314-win_amd64.whl", hash = "sha256:32ef5f4283a3be81913947d19608eacb7c6608026851123790cd9cc8982af34b"},
+    {file = "orjson-3.11.9-cp314-cp314-win_arm64.whl", hash = "sha256:eebdbdeef0094e4f5aefa20dcd4eb2368ab5e7a3b4edea27f1e7b2892e009cf9"},
+    {file = "orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f"},
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 description = "Core utilities for Python packages"
@@ -489,7 +573,7 @@ files = [
     {file = "polars-1.38.1-py3-none-any.whl", hash = "sha256:a29479c48fed4984d88b656486d221f638cba45d3e961631a50ee5fdde38cb2c"},
     {file = "polars-1.38.1.tar.gz", hash = "sha256:803a2be5344ef880ad625addfb8f641995cfd777413b08a10de0897345778239"},
 ]
-markers = {main = "extra == \"polars\""}
+markers = {main = "extra == \"dev\" or extra == \"polars\""}
 
 [package.dependencies]
 polars-runtime-32 = "1.38.1"
@@ -541,7 +625,7 @@ files = [
     {file = "polars_runtime_32-1.38.1-cp310-abi3-win_arm64.whl", hash = "sha256:6d07d0cc832bfe4fb54b6e04218c2c27afcfa6b9498f9f6bbf262a00d58cc7c4"},
     {file = "polars_runtime_32-1.38.1.tar.gz", hash = "sha256:04f20ed1f5c58771f34296a27029dc755a9e4b1390caeaef8f317e06fdfce2ec"},
 ]
-markers = {main = "extra == \"polars\""}
+markers = {main = "extra == \"dev\" or extra == \"polars\""}
 
 [[package]]
 name = "psutil"
@@ -1112,11 +1196,11 @@ files = [
 assets = ["sqlitedict"]
 bashplotlib = ["bashplotlib"]
 cache = ["diskcache"]
-dev = ["bashplotlib", "diskcache", "duckdb", "sqlitedict"]
+dev = ["bashplotlib", "diskcache", "duckdb", "polars", "sqlitedict"]
 duckdb = ["duckdb"]
 polars = ["polars"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "6bbec6af0a476c483250afcf674401b3fbb06f5fd14241b26b2ac42baa4f3e83"
+content-hash = "f49d7e57d3c8bc3e37698b1f240381d57a71e0bcd316cd813057ed626cfe0b70"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "xetrack"
-version = "0.6.0"
+version = "0.7.0"
 description = "A simple tool for benchamrking and tracking machine learning models and experiments."
 readme = "README.md"
 packages = [{ include = "xetrack" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ xxhash = ">=3.4.1"
 loguru = ">=0.7.0"
 tabulate = ">=0.9.0"
 cloudpickle = ">=2.0.0"
+orjson = ">=3.9.0"
 numpy = "^1.26"
 
 # Optional dependencies

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -2,7 +2,7 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 from xetrack.cli import app
 from typer.testing import CliRunner
 from xetrack import Reader, Tracker
-import json
+from xetrack._json import loads as json_loads
 import cloudpickle
 import pandas as pd
 runner = CliRunner()
@@ -24,7 +24,7 @@ def test_cli_head():
     assert 'timestamp' in result.output and 'track_id' in result.output and 'i' in result.output
 
     result = runner.invoke(app, args=['head', db1, '--json'])
-    assert 'timestamp' in json.loads(result.output)[0]
+    assert 'timestamp' in json_loads(result.output)[0]
 
 
 def test_cli_tail():
@@ -39,7 +39,7 @@ def test_cli_tail():
     assert 'timestamp' in result.output and 'track_id' in result.output and 'i' in result.output
 
     result = runner.invoke(app, args=['tail', db1, '--json'])
-    assert 'timestamp' in json.loads(result.output)[0]
+    assert 'timestamp' in json_loads(result.output)[0]
 
 
 def test_cli_columns():

--- a/tests/json_test.py
+++ b/tests/json_test.py
@@ -26,3 +26,26 @@ def test_dumps_with_indent():
 def test_roundtrip():
     data = {"key": "value", "num": 42, "nested": {"x": [1, 2, 3]}}
     assert loads(dumps(data)) == data
+
+
+def test_dumps_indent_always_two_spaces():
+    result = dumps({"a": {"b": 1}}, indent=4)
+    assert result == '{\n  "a": {\n    "b": 1\n  }\n}'
+
+
+def test_dumps_nan_becomes_null():
+    result = loads(dumps({"loss": float("nan")}))
+    assert result["loss"] is None
+
+
+def test_dumps_datetime():
+    import datetime
+    result = dumps({"t": datetime.datetime(2024, 1, 1)})
+    assert "2024-01-01" in result
+
+
+def test_json_decode_error_importable():
+    from xetrack._json import JSONDecodeError
+    import pytest
+    with pytest.raises(JSONDecodeError):
+        loads("not valid json")

--- a/tests/json_test.py
+++ b/tests/json_test.py
@@ -1,0 +1,28 @@
+from xetrack._json import dumps, loads
+
+
+def test_dumps_returns_str():
+    result = dumps({"a": 1})
+    assert isinstance(result, str)
+    assert '"a"' in result
+
+
+def test_loads_from_str():
+    result = loads('{"a": 1}')
+    assert result == {"a": 1}
+
+
+def test_loads_from_bytes():
+    result = loads(b'{"a": 1}')
+    assert result == {"a": 1}
+
+
+def test_dumps_with_indent():
+    result = dumps({"a": 1}, indent=2)
+    assert isinstance(result, str)
+    assert "\n" in result
+
+
+def test_roundtrip():
+    data = {"key": "value", "num": 42, "nested": {"x": [1, 2, 3]}}
+    assert loads(dumps(data)) == data

--- a/xetrack/_json.py
+++ b/xetrack/_json.py
@@ -1,16 +1,21 @@
 """Thin orjson wrapper matching stdlib json interface (str in, str out)."""
-from __future__ import annotations
-
 from typing import Any, Optional, Union
 
 import orjson
+from orjson import JSONDecodeError
+
+__all__ = ["dumps", "loads", "JSONDecodeError"]
 
 
 def dumps(obj: Any, *, indent: Optional[int] = None) -> str:
-    """Serialize *obj* to a JSON string (not bytes)."""
+    """Serialize *obj* to a JSON string (not bytes).
+
+    Note: orjson only supports 2-space indentation. Any non-None ``indent``
+    value produces 2-space indented output regardless of the value passed.
+    """
     opts = orjson.OPT_NON_STR_KEYS
     if indent is not None:
-        opts |= orjson.OPT_INDENT_2  # orjson only supports 2-space indent
+        opts |= orjson.OPT_INDENT_2
     return orjson.dumps(obj, option=opts).decode()
 
 

--- a/xetrack/_json.py
+++ b/xetrack/_json.py
@@ -1,0 +1,19 @@
+"""Thin orjson wrapper matching stdlib json interface (str in, str out)."""
+from __future__ import annotations
+
+from typing import Any, Optional, Union
+
+import orjson
+
+
+def dumps(obj: Any, *, indent: Optional[int] = None) -> str:
+    """Serialize *obj* to a JSON string (not bytes)."""
+    opts = orjson.OPT_NON_STR_KEYS
+    if indent is not None:
+        opts |= orjson.OPT_INDENT_2  # orjson only supports 2-space indent
+    return orjson.dumps(obj, option=opts).decode()
+
+
+def loads(s: Union[str, bytes]) -> Any:
+    """Deserialize a JSON string or bytes to a Python object."""
+    return orjson.loads(s)

--- a/xetrack/cli.py
+++ b/xetrack/cli.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Literal, Union, List
 import typer
 from xetrack import Reader, copy as copy_db
-from json import dumps
+from xetrack._json import dumps
 from xetrack._dataframe import (
     df_columns, df_describe, df_filter_eq, df_column_max, df_column_min,
     df_select_columns, df_to_dict_records, df_to_markdown, df_unique_series,

--- a/xetrack/cli.py
+++ b/xetrack/cli.py
@@ -25,7 +25,7 @@ def head(db: str = typer.Argument(help='path to database'),
          table: str = typer.Option("default", help="Name of the table to read from")):
     """Show the first lines of the database events table"""
     df = Reader(db, engine=_parse_engine(engine), table=table).to_df(head=n)
-    result = dumps(df_to_dict_records(df), indent=4) if json else df_to_markdown(df)
+    result = dumps(df_to_dict_records(df), indent=2) if json else df_to_markdown(df)
     typer.echo(result)
 
 
@@ -37,7 +37,7 @@ def tail(db: str = typer.Argument(help='path to database'),
          table: str = typer.Option("default", help="Name of the table to read from")):
     """Show the last lines of the database events table"""
     df = Reader(db, engine=_parse_engine(engine), table=table).to_df(tail=n)
-    result = dumps(df_to_dict_records(df), indent=4) if json else df_to_markdown(df)
+    result = dumps(df_to_dict_records(df), indent=2) if json else df_to_markdown(df)
     typer.echo(result)
 
 

--- a/xetrack/logging.py
+++ b/xetrack/logging.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import sys
-import json
+from xetrack._json import dumps as json_dumps, loads as json_loads
+import orjson
 import os
 from typing import Dict, List, Optional, Union, Any
 import re
@@ -131,10 +132,10 @@ class Logger:
         # Try to parse message as JSON if it contains structured data
         try:
             if message.strip().startswith('{'):
-                data = json.loads(message)
+                data = json_loads(message)
             else:
                 data = {"message": message}
-        except (json.JSONDecodeError, AttributeError):
+        except (orjson.JSONDecodeError, AttributeError):
             data = {"message": str(message)}
 
         # Create flattened JSONL entry
@@ -153,7 +154,7 @@ class Logger:
         if record.get("extra"):
             jsonl_entry["extra"] = record["extra"]
 
-        return json.dumps(jsonl_entry) + "\n"
+        return json_dumps(jsonl_entry) + "\n"
 
     def experiment(self, params: Dict[str, Any]):
         self.log(params, LOGURU_PARAMS.EXPERIMENT, indent=4)
@@ -174,7 +175,7 @@ class Logger:
     ) -> Any:
         """Create a monitoring log from a dictionary, a list of dictionaries, or a DataFrame."""
         if isinstance(data, dict):
-            self.logger.log(level, json.dumps(data, indent=indent))
+            self.logger.log(level, json_dumps(data, indent=indent))
         elif isinstance(data, list):
             for row in data:
                 self.monitor(row)
@@ -227,12 +228,12 @@ class Logger:
     ) -> Optional[Dict[str, Any]]:
         """return a relevent log entry from a structured log line"""
         if line.startswith('{"text":') and self.is_tracked_entry(line):
-            line_json = json.loads(line)
+            line_json = json_loads(line)
             log_text = line_json["text"]
             meta, text = log_text.split(LOGURU_PARAMS.DELIMITER)
             if level and level not in meta:
                 return None
-            return json.loads(text.strip())
+            return json_loads(text.strip())
 
     def read_log(self, path: str, level: Optional[str] = None) -> List[Dict[str, Any]]:
         data_list = []
@@ -247,9 +248,9 @@ class Logger:
                     # If there is an ongoing JSON string, parse it before starting a new one
                     if json_string:
                         try:
-                            data = json.loads(json_string)
+                            data = json_loads(json_string)
                             data_list.append(data)
-                        except json.JSONDecodeError:
+                        except orjson.JSONDecodeError:
                             pass
                         json_string = ""
 
@@ -264,9 +265,9 @@ class Logger:
             # Parse the last JSON string if it exists
             if json_string:
                 try:
-                    data = json.loads(json_string)
+                    data = json_loads(json_string)
                     data_list.append(data)
-                except json.JSONDecodeError:
+                except orjson.JSONDecodeError:
                     pass
         return data_list
 

--- a/xetrack/logging.py
+++ b/xetrack/logging.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import sys
-from xetrack._json import dumps as json_dumps, loads as json_loads
-import orjson
+from xetrack._json import dumps as json_dumps, loads as json_loads, JSONDecodeError
 import os
 from typing import Dict, List, Optional, Union, Any
 import re
@@ -135,7 +134,7 @@ class Logger:
                 data = json_loads(message)
             else:
                 data = {"message": message}
-        except (orjson.JSONDecodeError, AttributeError):
+        except (JSONDecodeError, AttributeError):
             data = {"message": str(message)}
 
         # Create flattened JSONL entry
@@ -157,7 +156,7 @@ class Logger:
         return json_dumps(jsonl_entry) + "\n"
 
     def experiment(self, params: Dict[str, Any]):
-        self.log(params, LOGURU_PARAMS.EXPERIMENT, indent=4)
+        self.log(params, LOGURU_PARAMS.EXPERIMENT, indent=2)
 
     def track(self, data: Union[Dict[str, Any], Any, List[Dict[str, Any]]]):
         return self.log(data, LOGURU_PARAMS.TRACKING)
@@ -250,7 +249,7 @@ class Logger:
                         try:
                             data = json_loads(json_string)
                             data_list.append(data)
-                        except orjson.JSONDecodeError:
+                        except JSONDecodeError:
                             pass
                         json_string = ""
 
@@ -267,7 +266,7 @@ class Logger:
                 try:
                     data = json_loads(json_string)
                     data_list.append(data)
-                except orjson.JSONDecodeError:
+                except JSONDecodeError:
                     pass
         return data_list
 

--- a/xetrack/reader.py
+++ b/xetrack/reader.py
@@ -166,14 +166,14 @@ class Reader:
             >>> print(df.columns)
             Index(['timestamp', 'level', 'accuracy', 'loss', ...])
         """
-        import json
+        from xetrack._json import loads as json_loads
 
         data = []
         with open(path, 'r') as f:
             for line in f:
                 line = line.strip()
                 if line:
-                    entry = json.loads(line)
+                    entry = json_loads(line)
                     # Entry is already flattened, use it directly
                     data.append(entry)
 

--- a/xetrack/reader.py
+++ b/xetrack/reader.py
@@ -5,6 +5,7 @@ from typing import Any, Optional, Literal
 from xetrack.engine import SqliteEngine
 from xetrack.config import SCHEMA_PARAMS
 from xetrack.logging import Logger
+from xetrack._json import loads as json_loads
 from xetrack._dataframe import (
     cursor_to_dataframe, dataframe_from_dicts, empty_dataframe,
     df_sort, df_is_empty, df_dropna_all,
@@ -166,8 +167,6 @@ class Reader:
             >>> print(df.columns)
             Index(['timestamp', 'level', 'accuracy', 'loss', ...])
         """
-        from xetrack._json import loads as json_loads
-
         data = []
         with open(path, 'r') as f:
             for line in f:


### PR DESCRIPTION
## Summary
- Add `orjson>=3.9.0` as core dependency for faster JSON serialization
- Create `xetrack/_json.py` thin wrapper (`dumps`/`loads`) that returns `str` instead of orjson's native `bytes`
- Migrate all stdlib `json` usage across `logging.py`, `cli.py`, `reader.py`, and tests

## Test plan
- [x] New unit tests for `_json.py` wrapper (roundtrip, types, indent)
- [x] Full test suite passes (160 passed, 1 skipped)
- [x] Zero remaining `import json` / `from json` in codebase